### PR TITLE
Persist CF status and improve auth handling

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -17,16 +17,8 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     );
   }
 
-  if (!user || isCfUser === false) {
+  if (!user || isCfUser === false || isCfUser === null) {
     return <Navigate to="/login" replace />;
-  }
-
-  if (isCfUser === null) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600"></div>
-      </div>
-    );
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- cache CF user flag in session metadata and localStorage to avoid repeated RPC calls
- mark CF check failures as unauthorized and sign out
- redirect to login when CF flag is missing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689168eaf0488323893a8c444b4815f0